### PR TITLE
added some helpful readers to the request, response, and response_status classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Requests are encoded as BSON hashes when transmitted in messages.
   'name':    'some_service',
   'params':  'something'
 }
+
+request = Sanford::Protocol::Request.parse(a_bson_request_hash)
+request.version  #=> "v1"
+request.name     #=> "some_service"
+request.params   #=> "something"
+request.to_s     #=> "[v1] some_service"
 ```
 
 ## Response
@@ -57,6 +63,16 @@ Responses are encoded as BSON hashes when transmitted in messages.
 { 'status': [ 200, 'The request was successful.' ]
   'data':   true
 }
+
+response = Sanford::Protocol::Response.parse(a_bson_response_hash)
+response.status.code    #=> 200
+response.status.to_i    #=> 200
+response.status.name    #=> "OK"
+response.status.message #=> "The request was successful."
+response.status.to_s    #=> "[200, OK]"
+response.code           #=> 200
+response.to_s           #=> "[200, OK]"
+response.data           #=> true
 ```
 
 ### Status Codes

--- a/lib/sanford-protocol/request.rb
+++ b/lib/sanford-protocol/request.rb
@@ -17,6 +17,8 @@ module Sanford::Protocol
       }
     end
 
+    def to_s; "[#{version}] #{name}"; end
+
     def valid?
       if !version
         [ false, "The request doesn't contain a version." ]

--- a/lib/sanford-protocol/response.rb
+++ b/lib/sanford-protocol/response.rb
@@ -16,6 +16,9 @@ module Sanford::Protocol
       super(build_status(status), data)
     end
 
+    def code; status.code; end
+    def to_s; status.to_s; end
+
     def to_hash
       { 'status' => [ status.code, status.message ],
         'data'   => data
@@ -24,9 +27,7 @@ module Sanford::Protocol
 
     def inspect
       reference = '0x0%x' % (self.object_id << 1)
-      "#<#{self.class}:#{reference}"\
-      " @status=#{status.inspect}"\
-      " @data=#{data.inspect}>"
+      "#<#{self.class}:#{reference} @status=#{status} @data=#{data.inspect}>"
     end
 
     private

--- a/lib/sanford-protocol/response_status.rb
+++ b/lib/sanford-protocol/response_status.rb
@@ -9,14 +9,14 @@ module Sanford::Protocol
     end
 
     def code; code_obj.number; end
+    alias_method :to_i, :code
+
     def name; code_obj.name;   end
     def to_s; code_obj.to_s;   end
 
     def inspect
       reference = '0x0%x' % (self.object_id << 1)
-      "#<#{self.class}:#{reference}"\
-      " @code=#{code_obj}"\
-      " @message=#{message.inspect}>"
+      "#<#{self.class}:#{reference} @code=#{code_obj} @message=#{message.inspect}>"
     end
 
     class Code < Struct.new(:number, :name)

--- a/test/unit/request_tests.rb
+++ b/test/unit/request_tests.rb
@@ -13,6 +13,10 @@ class Sanford::Protocol::Request
     should have_instance_methods :version, :name, :params, :to_hash, :valid?
     should have_class_methods :parse
 
+    should "return it's version and name with #to_s" do
+      assert_equal "[#{subject.version}] #{subject.name}", subject.to_s
+    end
+
     should "return an instance of a Sanford::Protocol::Request given a hash using #parse" do
       # using BSON messages are hashes
       hash = {

--- a/test/unit/response_status_tests.rb
+++ b/test/unit/response_status_tests.rb
@@ -11,7 +11,7 @@ class Sanford::Protocol::ResponseStatus
     subject{ @status }
 
     should have_readers :code_obj, :message
-    should have_instance_methods :code, :name
+    should have_instance_methods :code, :name, :to_i
 
     should "know it's code name" do
       named  = Sanford::Protocol::ResponseStatus.new(200)
@@ -21,7 +21,7 @@ class Sanford::Protocol::ResponseStatus
       assert_equal nil,  unamed.name
     end
 
-    should "know it's code numbers" do
+    should "know it's code number" do
       Code::NUMBERS.each do |name, value|
         status = Sanford::Protocol::ResponseStatus.new(name)
         assert_equal value, status.code
@@ -29,6 +29,10 @@ class Sanford::Protocol::ResponseStatus
 
       unamed = Sanford::Protocol::ResponseStatus.new('unamed')
       assert_equal 0, unamed.code
+    end
+
+    should "return it's code number with #to_i" do
+      assert_equal subject.code, subject.to_i
     end
 
     should "return it's code number and code name with #to_s" do

--- a/test/unit/response_tests.rb
+++ b/test/unit/response_tests.rb
@@ -10,8 +10,16 @@ class Sanford::Protocol::Response
     end
     subject{ @response }
 
-    should have_instance_methods :status, :data, :to_hash
+    should have_instance_methods :status, :code, :data, :to_hash, :to_s
     should have_class_methods :parse
+
+    should "return its status#code with #code" do
+      assert_equal subject.status.code, subject.code
+    end
+
+    should "return its status#to_s with #to_s" do
+      assert_equal subject.status.to_s, subject.to_s
+    end
 
     should "return an instance of a Sanford::Protocol::Response given a hash using #parse" do
       # using BSON messages are hashes
@@ -36,6 +44,7 @@ class Sanford::Protocol::Response
 
       assert_equal expected, subject.to_hash
     end
+
   end
 
   # Somewhat of a system test, want to make sure if Response is passed some


### PR DESCRIPTION
Added because it became obvious the would be helpful when developing
out Sanford and AndSon.

I added `#to_s` on the Request.  I added `#to_i` on the ResponseStatus.
I added `#code` and `#to_s` on the Response.  I also added supporting
README docs.
