### PR TITLE
adding optional timeout to Connection#read

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ connection.write(outgoing_data)
 
 For incoming messages, it reads them off the socket, validate them, and return the decoded body data.  For outgoing messages, it encodes the message body from given data, adds the appropiate message headers, and writes the message to the socket.
 
+#### Timeout
+
+When reading data from a connection, you can optionally pass a timeout value.  If given, the connection will block and wait until data is ready to be read.  If a timeout occurs, the connection will raise `TimeoutError`.
+
+```ruby
+begin
+  connection.read(10)  # timeout after waiting on data for 10s
+rescue Sanford::Protocol::TimeoutError => err
+  puts "timeout - so sad :("
+end
+```
+
 ### Requests And Responses
 
 Request and response objects have helpers for sending and receiving data using a connection.

--- a/lib/sanford-protocol/connection.rb
+++ b/lib/sanford-protocol/connection.rb
@@ -19,7 +19,8 @@ module Sanford::Protocol
     # |   msg version   |  msg body size  |       msg body       |
     # |-----------------|-----------------|----------------------|
 
-    def read
+    def read(timeout=nil)
+      wait_for_data(timeout) if timeout
       MsgVersion.new{ @socket.read msg_version.bytesize }.validate!
       size = MsgSize.new{ @socket.decode msg_size, msg_size.bytes }.validate!.value
       return MsgBody.new{ @socket.decode msg_body, size           }.validate!.value
@@ -32,23 +33,38 @@ module Sanford::Protocol
       @socket.write(msg_version, size, body)
     end
 
-    class Socket < Struct.new(:tcp_socket)
-      def decode(handler, num_bytes)
-        handler.decode(read(num_bytes))
-      end
+    private
 
-      def encode(handler, data)
-        handler.encode data
-      end
-
-      def read(number_of_bytes)
-        tcp_socket.recvfrom(number_of_bytes).first
-      end
-
-      def write(*binary_strings)
-        tcp_socket.send(binary_strings.join, 0)
+    def wait_for_data(timeout)
+      if IO.select([ @socket.tcp_socket ], nil, nil, timeout).nil?
+        raise TimeoutError.new(timeout)
       end
     end
 
   end
+
+  class Socket < Struct.new(:tcp_socket)
+    def decode(handler, num_bytes)
+      handler.decode(read(num_bytes))
+    end
+
+    def encode(handler, data)
+      handler.encode data
+    end
+
+    def read(number_of_bytes)
+      tcp_socket.recvfrom(number_of_bytes).first
+    end
+
+    def write(*binary_strings)
+      tcp_socket.send(binary_strings.join, 0)
+    end
+  end
+
+  class TimeoutError < RuntimeError
+    def initialize(timeout)
+      super "Timed out waiting for data to read (#{timeout}s)."
+    end
+  end
+
 end

--- a/test/unit/connection_tests.rb
+++ b/test/unit/connection_tests.rb
@@ -24,4 +24,19 @@ class Sanford::Protocol::Connection
     end
   end
 
+  class TimeoutTests < BaseTests
+    desc "when timing out on a read"
+    setup do
+      IO.stubs(:select).returns(nil) # mock IO.select behavior when it times out
+    end
+    teardown do
+      IO.unstub(:select)
+    end
+
+    should "raise `TimeoutError` if given a timeout value" do
+      assert_raises(Sanford::Protocol::TimeoutError) { subject.read(1) }
+    end
+
+  end
+
 end


### PR DESCRIPTION
When reading data from a connection, you can optionally
pass a timeout value.  If given, the connection will block
and wait until data is ready to be read.  If a timeout occurs,
the connection will raise `TimeoutError`.
