### PR TITLE
Added a 'timeout' response code

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This is the list of defined status codes.
 * `200` - `ok` - The request was successful.
 * `400` - `bad_request` - The request couldn't be read. This is usually because it was not formed correctly.
 * `404` - `not_found` - The server couldn't find something requested.
+* `408` - `timeout` - A client connected but didn't write a request before the server timeod out waiting for one.
 * `500` - `error` - The server errored responding to the request.
 
 In addition to these, a service can return custom status codes, but they should use a number greater than or equal to `600` to avoid collisions with Sanford's defined status codes.

--- a/lib/sanford-protocol/response_status.rb
+++ b/lib/sanford-protocol/response_status.rb
@@ -24,6 +24,7 @@ module Sanford::Protocol
         'ok'          => 200,
         'bad_request' => 400,
         'not_found'   => 404,
+        'timeout'     => 408,
         'error'       => 500
       }.freeze
 


### PR DESCRIPTION
This is to allow servers to respond with a specific response when they timeout
waiting on a request from a client. This follow HTTP's status codes as well.
