### PR TITLE
Defined `Connection#close`

### DIFF
--- a/lib/sanford-protocol/connection.rb
+++ b/lib/sanford-protocol/connection.rb
@@ -33,6 +33,10 @@ module Sanford::Protocol
       @socket.write(msg_version, size, body)
     end
 
+    def close
+      @socket.close
+    end
+
     private
 
     def wait_for_data(timeout)
@@ -58,6 +62,10 @@ module Sanford::Protocol
 
     def write(*binary_strings)
       tcp_socket.send(binary_strings.join, 0)
+    end
+
+    def close
+      tcp_socket.close rescue false
     end
   end
 

--- a/lib/sanford-protocol/test/fake_socket.rb
+++ b/lib/sanford-protocol/test/fake_socket.rb
@@ -47,5 +47,13 @@ module Sanford::Protocol::Test
       @out << bytes
     end
 
+    def close
+      @closed = true
+    end
+
+    def closed?
+      !!@closed
+    end
+
   end
 end

--- a/test/unit/connection_tests.rb
+++ b/test/unit/connection_tests.rb
@@ -12,7 +12,7 @@ class Sanford::Protocol::Connection
     end
     subject{ @connection }
 
-    should have_instance_methods :read, :write
+    should have_instance_methods :read, :write, :close
 
     should "read messages off the socket with #read" do
       assert_equal @data, subject.read
@@ -21,6 +21,11 @@ class Sanford::Protocol::Connection
     should "write messages to the socket with #write" do
       subject.write(@data)
       assert_equal @msg, @socket.out
+    end
+
+    should "close the socket with #close" do
+      subject.close
+      assert @socket.closed?
     end
   end
 


### PR DESCRIPTION
This was accidentally left off and is needed to properly close a `TCPSocket`
when done working with it.

Fixes #6
