### PR TITLE
Added stringifying hash keys for request params

### DIFF
--- a/lib/sanford-protocol/request.rb
+++ b/lib/sanford-protocol/request.rb
@@ -16,7 +16,7 @@ module Sanford::Protocol
 
     def initialize(version, name, params)
       self.validate!(version, name, params)
-      @version, @name, @params = version, name, params
+      @version, @name, @params = version, name, self.stringify(params)
     end
 
     def to_hash
@@ -47,6 +47,17 @@ module Sanford::Protocol
         "The request's params are not a valid BSON document."
       end
       raise(BadRequestError, problem) if problem
+    end
+
+    def stringify(object)
+      case(object)
+      when Hash
+        object.inject({}){|h, (k, v)| h.merge({ k.to_s => self.stringify(v) }) }
+      when Array
+        object.map{|item| self.stringify(item) }
+      else
+        object
+      end
     end
 
   end

--- a/test/unit/request_tests.rb
+++ b/test/unit/request_tests.rb
@@ -17,6 +17,15 @@ class Sanford::Protocol::Request
       assert_equal "[#{subject.version}] #{subject.name}", subject.to_s
     end
 
+    should "stringify params keys" do
+      request = Sanford::Protocol::Request.new('v1', 'service', {
+        1       => 1,
+        :symbol => :symbol
+      })
+      expected = { "1" => 1, "symbol" => :symbol }
+      assert_equal expected, request.params
+    end
+
     should "return an instance of a Sanford::Protocol::Request given a hash using #parse" do
       # using BSON messages are hashes
       hash = {


### PR DESCRIPTION
This should help with more consistent behavior (when using Symbols and String
keys) and keep BSON from throwing exceptions when keys arent Symbols or Strings.
