### PR TITLE
Upgrade to increase the protocol's performance

### DIFF
--- a/lib/sanford-protocol/msg_data.rb
+++ b/lib/sanford-protocol/msg_data.rb
@@ -11,7 +11,6 @@ module Sanford::Protocol
     attr_reader :value
 
     def initialize(called_from=nil, &get_value)
-      @called_from = called_from || caller
 
       # By default, any exceptions from getting the value are "hidden" behind a
       # more general `BadMessageError`. In non-debug scenarios this is ideal and
@@ -21,6 +20,7 @@ module Sanford::Protocol
       begin
         @value = get_value.call
       rescue Exception => err
+        @called_from = called_from || caller
         ENV['SANFORD_PROTOCOL_DEBUG'] ? raise(err) : self.error!(self.get_value_error)
       end
     end

--- a/lib/sanford-protocol/request.rb
+++ b/lib/sanford-protocol/request.rb
@@ -16,13 +16,13 @@ module Sanford::Protocol
 
     def initialize(version, name, params)
       self.validate!(version, name, params)
-      @version, @name, @params = version, name, self.stringify(params)
+      @version, @name, @params = version, name, params
     end
 
     def to_hash
       { 'version' => version,
         'name'    => name,
-        'params'  => params
+        'params'  => self.stringify(params)
       }
     end
 

--- a/test/unit/request_tests.rb
+++ b/test/unit/request_tests.rb
@@ -17,15 +17,6 @@ class Sanford::Protocol::Request
       assert_equal "[#{subject.version}] #{subject.name}", subject.to_s
     end
 
-    should "stringify params keys" do
-      request = Sanford::Protocol::Request.new('v1', 'service', {
-        1       => 1,
-        :symbol => :symbol
-      })
-      expected = { "1" => 1, "symbol" => :symbol }
-      assert_equal expected, request.params
-    end
-
     should "return an instance of a Sanford::Protocol::Request given a hash using #parse" do
       # using BSON messages are hashes
       hash = {
@@ -41,16 +32,21 @@ class Sanford::Protocol::Request
       assert_equal hash['params'],   request.params
     end
 
-    should "return the request as a hash with #to_hash" do
-      # using BSON messages are hashes
+    should "return the request as a hash with stringified params with #to_hash" do
+      # using BSON, messages are hashes
+      request = Sanford::Protocol::Request.new('v1', 'service', {
+        1       => 1,
+        :symbol => :symbol
+      })
       expected = {
         'version' => 'v1',
-        'name'    => 'some_service',
-        'params'  => { 'key' => 'value' }
+        'name'    => 'service',
+        'params'  => { '1' => 1, 'symbol' => :symbol }
       }
 
-      assert_equal expected, subject.to_hash
+      assert_equal expected, request.to_hash
     end
+
   end
 
   class ValidTests < BaseTests


### PR DESCRIPTION
These changes specifically enchance the performance of Sanford.
Their were 2 places that were causing slowdowns: getting ruby's
`caller` in `MsgData` and stringifying params in `Request`. I've
adjusted the `MsgData` class to only get the `caller` when
needed (when an error has occurred). This keeps it out of the
regular processing of requests, where it's not needed. I moved the
stringifying of `Request` params in the `to_hash` method. This
effectively moves stringifying params only when a request is
going to be encoded using BSON. This means server `Sanford` will
never strinfigy request params (and it shouldn't need to) and
only the client, `AndSon` will (and it should).

Closes #12
