### PR TITLE
Raise custom error when a socket read stream is closed immediately

### DIFF
--- a/lib/sanford-protocol/test/fake_socket.rb
+++ b/lib/sanford-protocol/test/fake_socket.rb
@@ -55,5 +55,13 @@ module Sanford::Protocol::Test
       !!@closed
     end
 
+    def eof
+      @eof = true
+    end
+
+    def eof?
+      !!@eof
+    end
+
   end
 end


### PR DESCRIPTION
When a remote connection closes the socket before the protocol
can read anything, it would previously read off an empty string
and throw a protocol version error. This modifies reading from
the connection to instead throw a specific exception. This will
allow Sanford servers to detect this and handle it however they
like. This behavior is typical of a keep-alive check. It will
simply make sure it can bind and then close the connection.
