### PR TITLE
Provide `peek` method for connections

### DIFF
--- a/lib/sanford-protocol/test/fake_socket.rb
+++ b/lib/sanford-protocol/test/fake_socket.rb
@@ -55,13 +55,5 @@ module Sanford::Protocol::Test
       !!@closed
     end
 
-    def eof
-      @eof = true
-    end
-
-    def eof?
-      !!@eof
-    end
-
   end
 end

--- a/test/unit/fake_socket_tests.rb
+++ b/test/unit/fake_socket_tests.rb
@@ -41,8 +41,7 @@ class Sanford::Protocol::Test::FakeSocket
     should "pull `in` data using #recv" do
       recv_data = subject.recv(@in_data.bytesize)
 
-      assert_kind_of ::Array, recv_data
-      assert_equal @in_data, recv_data.first
+      assert_equal @in_data, recv_data
     end
 
     should "reset its `in` data using #reset" do


### PR DESCRIPTION
This uses `Socket::MSG_PEEK` to look at the first byte of data on
the socket without reading it off. This allows Sanford servers to
check if anything has been written to the connection. Typical
"keep-alive" behavior opens and then immediately closes the
connection. The only way to detect this is to see if
reading/peeking from the socket returns nothing (after waiting).
With this, servers can check for keep-alive requests and handle
them appropriately.

@kellyredding - This is related to redding/sanford#47.
