### PR TITLE
Use `recv` instead of `recvfrom`

### DIFF
--- a/lib/sanford-protocol/connection.rb
+++ b/lib/sanford-protocol/connection.rb
@@ -69,7 +69,7 @@ module Sanford::Protocol
     end
 
     def read(number_of_bytes)
-      tcp_socket.recvfrom(number_of_bytes).first
+      tcp_socket.recv(number_of_bytes)
     end
 
     def write(*binary_strings)

--- a/lib/sanford-protocol/test/fake_socket.rb
+++ b/lib/sanford-protocol/test/fake_socket.rb
@@ -39,8 +39,8 @@ module Sanford::Protocol::Test
 
     # Socket methods -- requied by Sanford::Protocol
 
-    def recvfrom(number_of_bytes)
-      [ @in.read(number_of_bytes.to_i) || "" ]
+    def recv(number_of_bytes, flags = nil)
+      @in.read(number_of_bytes.to_i) || ""
     end
 
     def send(bytes, flag)

--- a/test/unit/fake_socket_tests.rb
+++ b/test/unit/fake_socket_tests.rb
@@ -13,7 +13,7 @@ class Sanford::Protocol::Test::FakeSocket
 
     should have_cmeths :with_request, :with_msg_body, :with_encoded_msg_body
     should have_imeths :in, :out, :reset
-    should have_imeths :recvfrom, :send
+    should have_imeths :recv, :send
 
     should "have no `in` or `out` data by default" do
       assert_empty subject.in
@@ -38,11 +38,11 @@ class Sanford::Protocol::Test::FakeSocket
       assert_equal @in_data, subject.in
     end
 
-    should "pull `in` data using #recvfrom" do
-      recvfrom_data = subject.recvfrom(@in_data.bytesize)
+    should "pull `in` data using #recv" do
+      recv_data = subject.recv(@in_data.bytesize)
 
-      assert_kind_of ::Array, recvfrom_data
-      assert_equal @in_data, recvfrom_data.first
+      assert_kind_of ::Array, recv_data
+      assert_equal @in_data, recv_data.first
     end
 
     should "reset its `in` data using #reset" do


### PR DESCRIPTION
This changes our usage of `recvfrom` to `recv`. I previously
didn't realize that both existed and when I did I looked up
the difference. `recvfrom` is intended to be used with
`sendto` and they don't have to "connect" (call `connect` or
bind) before being run. You can give `sendto` a socket address to
send to. On the other end, `recvfrom` returns the data read and
the socket address it read it from. `recv` works with `send` and
is intended to be used with connected sockets. This is always the
case for our usage, so I think it's better to not mix them and
always use `send` and `recv`.
