### PR TITLE
Add `close_write` to `Connection`

### DIFF
--- a/lib/sanford-protocol/connection.rb
+++ b/lib/sanford-protocol/connection.rb
@@ -43,6 +43,10 @@ module Sanford::Protocol
       @socket.close
     end
 
+    def close_write
+      @socket.close_write
+    end
+
     private
 
     def wait_for_data(timeout)
@@ -76,6 +80,10 @@ module Sanford::Protocol
 
     def close
       tcp_socket.close rescue false
+    end
+
+    def close_write
+      tcp_socket.close_write rescue false
     end
 
     protected

--- a/lib/sanford-protocol/test/fake_socket.rb
+++ b/lib/sanford-protocol/test/fake_socket.rb
@@ -55,5 +55,13 @@ module Sanford::Protocol::Test
       !!@closed
     end
 
+    def close_write
+      @write_stream_closed = true
+    end
+
+    def write_stream_closed?
+      !!@write_stream_closed
+    end
+
   end
 end

--- a/test/unit/connection_tests.rb
+++ b/test/unit/connection_tests.rb
@@ -12,7 +12,7 @@ class Sanford::Protocol::Connection
     end
     subject{ @connection }
 
-    should have_instance_methods :read, :write, :close, :peek
+    should have_instance_methods :read, :write, :close, :peek, :close_write
 
     should "read messages off the socket with #read" do
       assert_equal @data, subject.read
@@ -30,6 +30,11 @@ class Sanford::Protocol::Connection
 
     should "look at the first byte of data on the socket with #peek" do
       assert_equal @socket.in[0, 1], subject.peek
+    end
+
+    should "close the write stream of the socket with #close_write" do
+      subject.close_write
+      assert @socket.write_stream_closed?
     end
 
   end


### PR DESCRIPTION
This adds a `close_write` method to the connection class. This
will allow the Sanford server and AndSon client to close the
write stream of the socket after they have written a request or
response. The benefit is this alerts the remote socket that we
are done writing and they can begin reading.
