### PR TITLE
Remove version from a `Request`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ruby implementation of Sanford TCP communication protocol.
 
 ## The Protocol
 
-**Version**: `1`
+**Version**: `2`
 
 Sanford communicates using binary encoded messages.  Sanford messages are two headers and a body:
 
@@ -29,25 +29,22 @@ The Body is the content of the message.  It is a [BSON](http://bsonspec.org/) en
 
 ## Request
 
-A request is made up of 3 required parts: the version, the name, and the params.
+A request is made up of 2 required parts: the name, and the params.
 
-* **version** - (string) version of the requested API.
-* **name**    - (string) name of the requested API service.
-* **params**  - (document) data for the service call - must be a BSON document (ruby Hash, python dict, Javascript Object).
+* **name**   - (string) name of the requested API service.
+* **params** - (document) data for the service call - must be a BSON document (ruby Hash, python dict, Javascript Object).
 
 Requests are encoded as BSON hashes when transmitted in messages.
 
 ```ruby
-{ 'version' => 'v1',
-  'name'    => 'some_service',
-  'params'  => { 'key' => 'value' }
+{ 'name'   => 'some_service',
+  'params' => { 'key' => 'value' }
 }
 
 request = Sanford::Protocol::Request.parse(a_bson_request_hash)
-request.version  #=> "v1"
 request.name     #=> "some_service"
 request.params   #=> { 'key' => 'value' }
-request.to_s     #=> "[v1] some_service"
+request.to_s     #=> "some_service"
 ```
 
 ## Response
@@ -138,7 +135,7 @@ server_connection.write(outgoing_response.to_hash)
 
 # For a client...
 # use Request#to_hash to send a request
-outgoing_request = Sanford::Protocol::Request.new(name, version, params)
+outgoing_request = Sanford::Protocol::Request.new(name, params)
 client_connection.write(outgoing_request.to_hash)
 # use Response#parse to build an incoming response
 data_hash = client_connection.read

--- a/lib/sanford-protocol.rb
+++ b/lib/sanford-protocol.rb
@@ -14,7 +14,7 @@ module Sanford
     # README needs to be updated to display the current version and needs to
     # describe everything in this file.
 
-    VERSION = 1
+    VERSION = 2
 
     # The message version is the 1B encoding of the `VERSION` above. It is
     # encoded using Array#pack 'C' (8-bit unsigned integer).   The max value it

--- a/lib/sanford-protocol/request.rb
+++ b/lib/sanford-protocol/request.rb
@@ -1,6 +1,6 @@
 # The Request class models a specific type of Sanford message body and provides
 # a defined structure for it. A request requires a message body to contain a
-# version, name and params.
+# name and params.
 
 module Sanford; end
 module Sanford::Protocol
@@ -10,39 +10,35 @@ module Sanford::Protocol
   class Request
 
     def self.parse(body)
-      self.new(body['version'], body['name'], body['params'])
+      self.new(body['name'], body['params'])
     end
 
-    attr_reader :version, :name, :params
+    attr_reader :name, :params
 
-    def initialize(version, name, params)
-      self.validate!(version, name, params)
-      @version, @name, @params = version, name, params
+    def initialize(name, params)
+      self.validate!(name, params)
+      @name, @params = name, params
     end
 
     def to_hash
-      { 'version' => version,
-        'name'    => name,
-        'params'  => self.stringify(params)
+      { 'name'   => name,
+        'params' => self.stringify(params)
       }
     end
 
-    def to_s; "[#{version}] #{name}"; end
+    def to_s; name; end
 
     def inspect
       reference = '0x0%x' % (self.object_id << 1)
       "#<#{self.class}:#{reference}"\
-      " @version=#{version.inspect}"\
       " @name=#{name.inspect}"\
       " @params=#{params.inspect}>"
     end
 
     protected
 
-    def validate!(version, name, params)
-      problem = if !version
-        "The request doesn't contain a version."
-      elsif !name
+    def validate!(name, params)
+      problem = if !name
         "The request doesn't contain a name."
       elsif !params.kind_of?(Hash)
         "The request's params are not a valid BSON document."

--- a/sanford-protocol.gemspec
+++ b/sanford-protocol.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("bson", ["~> 1.7"])
 
-  gem.add_development_dependency("assert",       ["~> 2.0"])
+  gem.add_development_dependency("assert",       ["~> 2.3"])
   gem.add_development_dependency("assert-mocha", ["~> 1.0"])
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -25,7 +25,7 @@ class Assert::Context
   end
 
   def setup_some_request_data
-    @request_params = ['1', 'a_service', {:some => 'data'}]
+    @request_params = ['a_service', {:some => 'data'}]
     @request = Sanford::Protocol::Request.new(*@request_params)
     setup_some_msg_data(@request.to_hash)
   end

--- a/test/unit/protocol_tests.rb
+++ b/test/unit/protocol_tests.rb
@@ -13,7 +13,7 @@ module Sanford::Protocol
     should have_instance_methods :msg_version, :msg_size, :msg_body
 
     should "define the protocol version" do
-      assert_equal 1, subject::VERSION
+      assert_equal 2, subject::VERSION
     end
 
     should "encode the protocol version to a 1B binary string" do

--- a/test/unit/request_tests.rb
+++ b/test/unit/request_tests.rb
@@ -6,44 +6,40 @@ class Sanford::Protocol::Request
   class BaseTests < Assert::Context
     desc "Sanford::Protocol::Request"
     setup do
-      @request = Sanford::Protocol::Request.new('v1', 'some_service', { 'key' => 'value' })
+      @request = Sanford::Protocol::Request.new('some_service', { 'key' => 'value' })
     end
     subject{ @request }
 
-    should have_instance_methods :version, :name, :params, :to_hash
+    should have_instance_methods :name, :params, :to_hash
     should have_class_methods :parse
 
-    should "return it's version and name with #to_s" do
-      assert_equal "[#{subject.version}] #{subject.name}", subject.to_s
+    should "return it's name with #to_s" do
+      assert_equal subject.name, subject.to_s
     end
 
     should "return an instance of a Sanford::Protocol::Request given a hash using #parse" do
       # using BSON messages are hashes
       hash = {
-        'name'    => 'service_name',
-        'version' => 'service_version',
-        'params'  => { 'service_params' => 'yes' }
+        'name'   => 'service_name',
+        'params' => { 'service_params' => 'yes' }
       }
       request = Sanford::Protocol::Request.parse(hash)
 
       assert_instance_of Sanford::Protocol::Request, request
-      assert_equal hash['name'],     request.name
-      assert_equal hash['version'],  request.version
-      assert_equal hash['params'],   request.params
+      assert_equal hash['name'],   request.name
+      assert_equal hash['params'], request.params
     end
 
     should "return the request as a hash with stringified params with #to_hash" do
       # using BSON, messages are hashes
-      request = Sanford::Protocol::Request.new('v1', 'service', {
+      request = Sanford::Protocol::Request.new('service', {
         1       => 1,
         :symbol => :symbol
       })
       expected = {
-        'version' => 'v1',
-        'name'    => 'service',
-        'params'  => { '1' => 1, 'symbol' => :symbol }
+        'name'   => 'service',
+        'params' => { '1' => 1, 'symbol' => :symbol }
       }
-
       assert_equal expected, request.to_hash
     end
 
@@ -53,25 +49,19 @@ class Sanford::Protocol::Request
 
     should "not raise an exception with valid request args" do
       assert_nothing_raised do
-        Sanford::Protocol::Request.new('v1', 'name', {})
+        Sanford::Protocol::Request.new('name', {})
       end
     end
 
     should "raise an exception when there isn't a name arg" do
       assert_raises(Sanford::Protocol::BadRequestError) do
-        Sanford::Protocol::Request.new('v1', nil, {})
-      end
-    end
-
-    should "return false and a message when there isn't a version" do
-      assert_raises(Sanford::Protocol::BadRequestError) do
-        Sanford::Protocol::Request.new(nil, 'name', {})
+        Sanford::Protocol::Request.new(nil, {})
       end
     end
 
     should "return false and a message when the params are not a Hash" do
       assert_raises(Sanford::Protocol::BadRequestError) do
-        Sanford::Protocol::Request.new('v1', 'name', true)
+        Sanford::Protocol::Request.new('name', true)
       end
     end
   end


### PR DESCRIPTION
This removes having a separate version string for every request.
This goes to the more generic name and params only. For versioned
services, the version should be included as part of the service's
name. This is more flexible and in Sanford, make it more clear
that services can be versioned independently.
