### PR TITLE
test helper reorgs and cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ incoming_response = Sanford::Protocol::Response.parse(data_hash)
 
 ## Test Helpers
 
-A `FakeSocket` helper class and an associated `Test::Helpers` module are provided to help test receiving and sending Sanford::Protocol messages without using real sockets.
+A `FakeSocket` helper class and an associated `TestHelpers` module are provided to help test receiving and sending Sanford::Protocol messages without using real sockets.
 
 ```ruby
 # fake a socket with some incoming binary

--- a/lib/sanford-protocol/fake_socket.rb
+++ b/lib/sanford-protocol/fake_socket.rb
@@ -5,7 +5,9 @@ require 'sanford-protocol/request'
 # environment. Instead of passing a real socket, pass an instance of this class.
 # It mimics the socket API that sanford is concerned with.
 
-module Sanford::Protocol::Test
+module Sanford; end
+module Sanford::Protocol
+
   class FakeSocket
 
     def self.with_request(*request_params)
@@ -64,4 +66,5 @@ module Sanford::Protocol::Test
     end
 
   end
+
 end

--- a/lib/sanford-protocol/response_status.rb
+++ b/lib/sanford-protocol/response_status.rb
@@ -3,6 +3,7 @@
 
 module Sanford; end
 module Sanford::Protocol
+
   class ResponseStatus < Struct.new(:code_obj, :message)
 
     def initialize(code, message = nil)
@@ -43,4 +44,5 @@ module Sanford::Protocol
     end
 
   end
+
 end

--- a/lib/sanford-protocol/test_helpers.rb
+++ b/lib/sanford-protocol/test_helpers.rb
@@ -1,25 +1,27 @@
-require 'sanford-protocol/test/fake_socket'
+require 'sanford-protocol/fake_socket'
+require 'sanford-protocol/connection'
 require 'sanford-protocol/response'
 
-module Sanford::Protocol::Test
+module Sandord; end
+module Sanford::Protocol
 
-  module Helpers
+  module TestHelpers
     extend self
 
     def fake_socket_with_request(*args)
-      FakeSocket.with_request(*args)
+      Sanford::Protocol::FakeSocket.with_request(*args)
     end
 
     def fake_socket_with_msg_body(*args)
-      FakeSocket.with_msg_body(*args)
+      Sanford::Protocol::FakeSocket.with_msg_body(*args)
     end
 
     def fake_socket_with_encoded_msg_body(*args)
-      FakeSocket.with_encoded_msg_body(*args)
+      Sanford::Protocol::FakeSocket.with_encoded_msg_body(*args)
     end
 
     def fake_socket_with(*args)
-      FakeSocket.new(*args)
+      Sanford::Protocol::FakeSocket.new(*args)
     end
 
     def read_response_from_fake_socket(from_fake_socket)
@@ -28,7 +30,7 @@ module Sanford::Protocol::Test
     end
 
     def read_written_response_from_fake_socket(from_fake_socket)
-      read_response_from_fake_socket(FakeSocket.new(from_fake_socket.out))
+      read_response_from_fake_socket(Sanford::Protocol::FakeSocket.new(from_fake_socket.out))
     end
 
   end

--- a/sanford-protocol.gemspec
+++ b/sanford-protocol.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("bson", ["~> 1.7"])
 
-  gem.add_development_dependency("assert",       ["~> 2.3"])
-  gem.add_development_dependency("assert-mocha", ["~> 1.0"])
+  gem.add_development_dependency("assert",       ["~> 2.10"])
+  gem.add_development_dependency("assert-mocha", ["~> 1.1"])
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,14 +9,14 @@ require 'pry'
 
 ENV['SANFORD_PROTOCOL_DEBUG'] = 'yes'
 
-require 'sanford-protocol/test/fake_socket'
-FakeSocket = Sanford::Protocol::Test::FakeSocket
+require 'sanford-protocol/fake_socket'
+FakeSocket = Sanford::Protocol::FakeSocket
 
 require 'assert-mocha' if defined?(Assert)
 
 class Assert::Context
 
-  def setup_some_msg_data(data=nil)
+  def setup_some_msg_data(data = nil)
     @data = data || { 'something' => true }
     @encoded_body    = Sanford::Protocol.msg_body.encode(@data)
     @encoded_size    = Sanford::Protocol.msg_size.encode(@encoded_body.bytesize)

--- a/test/unit/connection_tests.rb
+++ b/test/unit/connection_tests.rb
@@ -3,7 +3,7 @@ require 'sanford-protocol/connection'
 
 class Sanford::Protocol::Connection
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Sanford::Protocol::Connection"
     setup do
       setup_some_msg_data
@@ -39,7 +39,7 @@ class Sanford::Protocol::Connection
 
   end
 
-  class RealConnectionTests < BaseTests
+  class RealConnectionTests < UnitTests
 
     def start_server(options, &block)
       begin

--- a/test/unit/fake_socket_tests.rb
+++ b/test/unit/fake_socket_tests.rb
@@ -1,11 +1,12 @@
 require 'assert'
-require 'sanford-protocol/test/fake_socket'
+require 'sanford-protocol/fake_socket'
+
 require 'sanford-protocol/request'
 
-class Sanford::Protocol::Test::FakeSocket
+class Sanford::Protocol::FakeSocket
 
-  class BaseTests < Assert::Context
-    desc "a FakeSocket"
+  class UnitTests < Assert::Context
+    desc "Sanford::Protocol::FakeSocket"
     setup do
       @fs = FakeSocket.new
     end
@@ -27,7 +28,7 @@ class Sanford::Protocol::Test::FakeSocket
 
   end
 
-  class WithInDataTests < BaseTests
+  class WithInDataTests < UnitTests
     desc "created given some data"
     setup do
       @in_data = 'some in data'
@@ -51,7 +52,7 @@ class Sanford::Protocol::Test::FakeSocket
 
   end
 
-  class EncodedMessageTests < BaseTests
+  class EncodedMessageTests < UnitTests
     desc "with encoded msg data"
     setup do
       setup_some_msg_data
@@ -69,7 +70,7 @@ class Sanford::Protocol::Test::FakeSocket
 
   end
 
-  class RequestTests < BaseTests
+  class RequestTests < UnitTests
     desc "that is a request"
     setup do
       setup_some_request_data

--- a/test/unit/msg_data_tests.rb
+++ b/test/unit/msg_data_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'sanford-protocol/msg_data'
-require 'sanford-protocol'
+
+require 'sanford-protocol/connection'
 
 class Sanford::Protocol::MsgData
 

--- a/test/unit/request_tests.rb
+++ b/test/unit/request_tests.rb
@@ -3,15 +3,15 @@ require 'sanford-protocol/request'
 
 class Sanford::Protocol::Request
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Sanford::Protocol::Request"
     setup do
       @request = Sanford::Protocol::Request.new('some_service', { 'key' => 'value' })
     end
     subject{ @request }
 
-    should have_instance_methods :name, :params, :to_hash
-    should have_class_methods :parse
+    should have_imeths :name, :params, :to_hash
+    should have_cmeths :parse
 
     should "return it's name with #to_s" do
       assert_equal subject.name, subject.to_s
@@ -33,7 +33,7 @@ class Sanford::Protocol::Request
     should "return the request as a hash with stringified params with #to_hash" do
       # using BSON, messages are hashes
       request = Sanford::Protocol::Request.new('service', {
-        1       => 1,
+        1 => 1,
         :symbol => :symbol
       })
       expected = {
@@ -45,7 +45,7 @@ class Sanford::Protocol::Request
 
   end
 
-  class ValidTests < BaseTests
+  class ValidTests < UnitTests
 
     should "not raise an exception with valid request args" do
       assert_nothing_raised do

--- a/test/unit/response_status_tests.rb
+++ b/test/unit/response_status_tests.rb
@@ -3,7 +3,7 @@ require 'sanford-protocol/response_status'
 
 class Sanford::Protocol::ResponseStatus
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Sanford::Protocol::ResponseStatus"
     setup do
       @status = Sanford::Protocol::ResponseStatus.new(200, "OK")
@@ -11,7 +11,7 @@ class Sanford::Protocol::ResponseStatus
     subject{ @status }
 
     should have_readers :code_obj, :message
-    should have_instance_methods :code, :name, :to_i
+    should have_imeths :code, :name, :to_i
 
     should "know it's code name" do
       named  = Sanford::Protocol::ResponseStatus.new(200)

--- a/test/unit/response_tests.rb
+++ b/test/unit/response_tests.rb
@@ -3,15 +3,15 @@ require 'sanford-protocol/response'
 
 class Sanford::Protocol::Response
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Sanford::Protocol::Response"
     setup do
       @response = Sanford::Protocol::Response.new([ 672, 'YAR!' ], { 'something' => true })
     end
     subject{ @response }
 
-    should have_instance_methods :status, :code, :data, :to_hash, :to_s
-    should have_class_methods :parse
+    should have_imeths :status, :code, :data, :to_hash, :to_s
+    should have_cmeths :parse
 
     should "return its status#code with #code" do
       assert_equal subject.status.code, subject.code
@@ -49,7 +49,7 @@ class Sanford::Protocol::Response
 
   # Somewhat of a system test, want to make sure if Response is passed some
   # "fuzzy" args that it will build it's status object as expected
-  class StatusBuildingTests < BaseTests
+  class StatusBuildingTests < UnitTests
 
     should "build a status with it's code set, given an integer" do
       response = Sanford::Protocol::Response.new(574)
@@ -75,8 +75,8 @@ class Sanford::Protocol::Response
     should "build a status with a code and message set, when given both" do
       response = Sanford::Protocol::Response.new([ 348, "my message" ])
 
-      assert_equal 348,           response.status.code
-      assert_equal "my message",  response.status.message
+      assert_equal 348, response.status.code
+      assert_equal "my message", response.status.message
     end
   end
 

--- a/test/unit/sanford-protocol_tests.rb
+++ b/test/unit/sanford-protocol_tests.rb
@@ -1,16 +1,17 @@
+require 'assert'
+require 'sanford-protocol'
+
 # These tests are intended to be brittle and make sure the protocol conforms to
 # an expected spec. If any of these tests fail, you probably need to modify the
 # protocol's version constant.
 
-require 'assert'
-require 'sanford-protocol'
-
 module Sanford::Protocol
-  class BaseTests < Assert::Context
+
+  class UnitTests < Assert::Context
     desc "Sanford::Protocol"
     subject{ Sanford::Protocol }
 
-    should have_instance_methods :msg_version, :msg_size, :msg_body
+    should have_imeths :msg_version, :msg_size, :msg_body
 
     should "define the protocol version" do
       assert_equal 2, subject::VERSION

--- a/test/unit/test_helpers_tests.rb
+++ b/test/unit/test_helpers_tests.rb
@@ -1,11 +1,13 @@
 require 'assert'
-require 'sanford-protocol/test/helpers'
+require 'sanford-protocol/test_helpers'
 
-module Sanford::Protocol::Test::Helpers
+require 'sanford-protocol/response'
 
-  class BaseTests < Assert::Context
-    desc "the test helpers"
-    subject { Sanford::Protocol::Test::Helpers }
+module Sanford::Protocol::TestHelpers
+
+  class UnitTests < Assert::Context
+    desc "Sanford::Protocol::TestHelpers"
+    subject { Sanford::Protocol::TestHelpers }
 
     should have_imeths :fake_socket_with_request, :fake_socket_with_msg_body
     should have_imeths :fake_socket_with_encoded_msg_body, :fake_socket_with


### PR DESCRIPTION
This reorganizes the test helper files and cleans up the tests to
get them to our modern conventions.  There are no behavior changes,
just modernizing things in prep for new features.

@jcredding ready for review.
