### PR TITLE
force string request names

### DIFF
--- a/lib/sanford-protocol/request.rb
+++ b/lib/sanford-protocol/request.rb
@@ -17,7 +17,7 @@ module Sanford::Protocol
 
     def initialize(name, params)
       self.validate!(name, params)
-      @name, @params = name, params
+      @name, @params = name.to_s, params
     end
 
     def to_hash
@@ -40,7 +40,7 @@ module Sanford::Protocol
     def validate!(name, params)
       problem = if !name
         "The request doesn't contain a name."
-      elsif !params.kind_of?(Hash)
+      elsif !params.kind_of?(::Hash)
         "The request's params are not a valid BSON document."
       end
       raise(BadRequestError, problem) if problem

--- a/test/unit/request_tests.rb
+++ b/test/unit/request_tests.rb
@@ -13,11 +13,21 @@ class Sanford::Protocol::Request
     should have_imeths :name, :params, :to_hash
     should have_cmeths :parse
 
+    should "know its name and params" do
+      assert_equal 'some_service', subject.name
+      assert_equal({ 'key' => 'value' }, subject.params)
+    end
+
+    should "force string request names" do
+      request = Sanford::Protocol::Request.new(:symbol_service_name, {})
+      assert_equal 'symbol_service_name', request.name
+    end
+
     should "return it's name with #to_s" do
       assert_equal subject.name, subject.to_s
     end
 
-    should "return an instance of a Sanford::Protocol::Request given a hash using #parse" do
+    should "parse requests given a body hash" do
       # using BSON messages are hashes
       hash = {
         'name'   => 'service_name',


### PR DESCRIPTION
This forces requests to always have string names.  This helps ensure
requests will always be routed to handlers whether they were created
with string or symbol names.

Note, redding/sanford forces service handlers to be routed with
string names.  This ensures you won't get a 404 b/c you defined
the handler with a symbol name but made a client request with a
string name.

Related to redding/sanford#96.
Closes #22.

@jcredding ready for review.
