### PR TITLE
switch to the latest assert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'pry'
+gem 'pry', "~> 0.9.0"
 
 gem 'bson_ext', '~>1.7'

--- a/sanford-protocol.gemspec
+++ b/sanford-protocol.gemspec
@@ -19,6 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("bson", ["~> 1.7", "< 1.10.0"])
 
-  gem.add_development_dependency("assert",       ["~> 2.10"])
-  gem.add_development_dependency("assert-mocha", ["~> 1.1"])
+  gem.add_development_dependency("assert", ["~> 2.11"])
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,8 +12,6 @@ ENV['SANFORD_PROTOCOL_DEBUG'] = 'yes'
 require 'sanford-protocol/fake_socket'
 FakeSocket = Sanford::Protocol::FakeSocket
 
-require 'assert-mocha' if defined?(Assert)
-
 class Assert::Context
 
   def setup_some_msg_data(data = nil)


### PR DESCRIPTION
The latest assert adds its own native stubbing API.  The switches
to that.  No behavior changes - just test updates and cleanups.

@jcredding ready for review.  See how the new stubbing API feels here.
