### PR TITLE
Make `Request` and `Response` define equality operator

### DIFF
--- a/lib/sanford-protocol/request.rb
+++ b/lib/sanford-protocol/request.rb
@@ -35,6 +35,14 @@ module Sanford::Protocol
       " @params=#{params.inspect}>"
     end
 
+    def ==(other)
+      if other.kind_of?(self.class)
+        self.to_hash == other.to_hash
+      else
+        super
+      end
+    end
+
     protected
 
     def validate!(name, params)

--- a/lib/sanford-protocol/response.rb
+++ b/lib/sanford-protocol/response.rb
@@ -31,6 +31,14 @@ module Sanford::Protocol
       "#<#{self.class}:#{reference} @status=#{status} @data=#{data.inspect}>"
     end
 
+    def ==(other)
+      if other.kind_of?(self.class)
+        self.to_hash == other.to_hash
+      else
+        super
+      end
+    end
+
     private
 
     def build_status(status)

--- a/test/unit/request_tests.rb
+++ b/test/unit/request_tests.rb
@@ -53,6 +53,17 @@ class Sanford::Protocol::Request
       assert_equal expected, request.to_hash
     end
 
+    should "be comparable" do
+      match_request = Sanford::Protocol::Request.new(
+        subject.name.dup,
+        subject.params.dup
+      )
+      assert_equal match_request, subject
+
+      not_match_request = Sanford::Protocol::Request.new('other', {})
+      assert_not_equal not_match_request, subject
+    end
+
   end
 
   class ValidTests < UnitTests

--- a/test/unit/response_tests.rb
+++ b/test/unit/response_tests.rb
@@ -45,6 +45,17 @@ class Sanford::Protocol::Response
       assert_equal expected, subject.to_hash
     end
 
+    should "be comparable" do
+      match_response = Sanford::Protocol::Response.new(
+        subject.status.dup,
+        subject.data.dup
+      )
+      assert_equal match_response, subject
+
+      not_match_response = Sanford::Protocol::Response.new(123, {})
+      assert_not_equal not_match_response, subject
+    end
+
   end
 
   # Somewhat of a system test, want to make sure if Response is passed some


### PR DESCRIPTION
This makes `Request` and `Response` objects comparable by defining
the equality operator. This allows comparing them, which is useful
when testing.

@kellyredding - Ready for review.
