### PR TITLE
Add a `FakeConnection` for testing

### DIFF
--- a/lib/sanford-protocol/fake_connection.rb
+++ b/lib/sanford-protocol/fake_connection.rb
@@ -1,0 +1,46 @@
+module Sanford; end
+module Sanford::Protocol
+
+  class FakeConnection
+
+    attr_accessor :read_data, :peek_data, :write_data
+    attr_accessor :closed, :closed_write
+    attr_reader :read_timeout, :peek_timeout
+
+    def initialize(read_data = nil)
+      @read_data  = read_data || ""
+      @peek_data  = read_data ? read_data[1] : ""
+      @write_data = nil
+
+      @read_timeout = nil
+      @peek_timeout = nil
+
+      @closed = false
+      @closed_write = false
+    end
+
+    def read(timeout = nil)
+      @read_timeout = timeout
+      @read_data
+    end
+
+    def write(data)
+      @write_data = data
+    end
+
+    def peek(timeout = nil)
+      @peek_timeout = timeout
+      @peek_data
+    end
+
+    def close
+      @closed = true
+    end
+
+    def close_write
+      @closed_write = true
+    end
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,8 @@ ENV['SANFORD_PROTOCOL_DEBUG'] = 'yes'
 require 'sanford-protocol/fake_socket'
 FakeSocket = Sanford::Protocol::FakeSocket
 
+require 'test/support/factory'
+
 class Assert::Context
 
   def setup_some_msg_data(data = nil)

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,0 +1,6 @@
+require 'assert/factory'
+
+module Factory
+  extend Assert::Factory
+
+end

--- a/test/unit/fake_connection_tests.rb
+++ b/test/unit/fake_connection_tests.rb
@@ -1,0 +1,80 @@
+require 'assert'
+require 'sanford-protocol/fake_connection'
+
+class Sanford::Protocol::FakeConnection
+
+  class UnitTests < Assert::Context
+    desc "Sanford::Protocol::FakeConnection"
+    setup do
+      @read_data = Factory.binary
+      @fake_connection = Sanford::Protocol::FakeConnection.new(@read_data)
+    end
+    subject{ @fake_connection }
+
+    should have_accessors :read_data, :peek_data, :write_data
+    should have_accessors :closed, :closed_write
+    should have_readers :read_timeout, :peek_timeout
+    should have_imeths :read, :write, :peek, :close, :close_write
+
+    should "know its read data and peek data" do
+      assert_equal @read_data, subject.read_data
+      assert_equal @read_data[1], subject.peek_data
+    end
+
+    should "default its attributes" do
+      fake_connection = Sanford::Protocol::FakeConnection.new
+      assert_equal "", fake_connection.read_data
+      assert_equal "", fake_connection.peek_data
+      assert_nil fake_connection.write_data
+      assert_false fake_connection.closed
+      assert_false fake_connection.closed_write
+      assert_nil fake_connection.read_timeout
+      assert_nil fake_connection.peek_timeout
+    end
+
+    should "allow reading the read data using `read`" do
+      assert_nil subject.read_timeout
+      result = subject.read
+      assert_equal subject.read_data, result
+      assert_nil subject.read_timeout
+
+      timeout = Factory.integer
+      assert_nil subject.read_timeout
+      result = subject.read(timeout)
+      assert_equal timeout, subject.read_timeout
+    end
+
+    should "allow writing to the write data using `write`" do
+      data = Factory.boolean
+      assert_nil subject.write_data
+      subject.write(data)
+      assert_equal data, subject.write_data
+    end
+
+    should "allow reading the peek data using `peek`" do
+      assert_nil subject.peek_timeout
+      result = subject.peek
+      assert_equal subject.peek_data, result
+      assert_nil subject.peek_timeout
+
+      timeout = Factory.integer
+      assert_nil subject.peek_timeout
+      result = subject.peek(timeout)
+      assert_equal timeout, subject.peek_timeout
+    end
+
+    should "close itself using `close`" do
+      assert_false subject.closed
+      subject.close
+      assert_true subject.closed
+    end
+
+    should "close its write using `close_write`" do
+      assert_false subject.closed_write
+      subject.close_write
+      assert_true subject.closed_write
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a `FakeConnection` that has the same interface as a
`Connection` but doesn't work on a real socket. This is useful
for dependency injecting into tests to get the behavior of a
protocol connection without the overhead of using a real socket.

This also sets up a factory for the tests using asserts factory.
This should be used to help generate random data.

@kellyredding - Ready for review.
