### PR TITLE
Make `Response` have a friendlier interface

### DIFF
--- a/lib/sanford-protocol/response.rb
+++ b/lib/sanford-protocol/response.rb
@@ -17,8 +17,11 @@ module Sanford::Protocol
       super(build_status(status), data)
     end
 
-    def code; status.code; end
-    def to_s; status.to_s; end
+    def code;                  status.code;                  end
+    def code=(new_code);       status.code = new_code;       end
+    def message;               status.message;               end
+    def message=(new_message); status.message = new_message; end
+    def to_s;                  status.to_s;                  end
 
     def to_hash
       { 'status' => [ status.code, status.message ],

--- a/lib/sanford-protocol/response_status.rb
+++ b/lib/sanford-protocol/response_status.rb
@@ -10,8 +10,12 @@ module Sanford::Protocol
       super(Code.new(code), message)
     end
 
-    def code; code_obj.number; end
+    def code; self.code_obj.number; end
     alias_method :to_i, :code
+
+    def code=(new_code)
+      self.code_obj = Code.new(new_code)
+    end
 
     def name; code_obj.name; end
     def to_s; code_obj.to_s; end

--- a/test/unit/response_status_tests.rb
+++ b/test/unit/response_status_tests.rb
@@ -11,7 +11,7 @@ class Sanford::Protocol::ResponseStatus
     subject{ @status }
 
     should have_readers :code_obj, :message
-    should have_imeths :code, :name, :to_i
+    should have_imeths :code, :code=, :name, :to_i
 
     should "know it's code name" do
       named  = Sanford::Protocol::ResponseStatus.new(200)
@@ -33,6 +33,12 @@ class Sanford::Protocol::ResponseStatus
 
     should "return it's code number with #to_i" do
       assert_equal subject.code, subject.to_i
+    end
+
+    should "allow setting its code" do
+      number = Factory.integer
+      subject.code = number
+      assert_equal number, subject.code
     end
 
     should "return it's code number and code name with #to_s" do

--- a/test/unit/response_tests.rb
+++ b/test/unit/response_tests.rb
@@ -10,15 +10,21 @@ class Sanford::Protocol::Response
     end
     subject{ @response }
 
-    should have_imeths :status, :code, :data, :to_hash, :to_s
+    should have_imeths :status, :data, :to_hash
+    should have_imeths :code, :code=, :message, :message=, :to_s
     should have_cmeths :parse
 
-    should "return its status#code with #code" do
+    should "demeter its status" do
       assert_equal subject.status.code, subject.code
-    end
-
-    should "return its status#to_s with #to_s" do
+      assert_equal subject.status.message, subject.message
       assert_equal subject.status.to_s, subject.to_s
+
+      new_code = Factory.integer
+      new_message = Factory.string
+      subject.code = new_code
+      subject.message = new_message
+      assert_equal new_code, subject.code
+      assert_equal new_message, subject.message
     end
 
     should "return an instance of a Sanford::Protocol::Response given a hash using #parse" do


### PR DESCRIPTION
This makes the `Response` interface friendlier, primarily for use
in tests. This demeters the `Response.status` message so it doesn't
have to be accessed through `status.message`. This also adds
writers for code and message which makes them consistent with data
and is helpful when testing responses. Specifically, `AndSon`
wants to be able to configure protocol responses and its convenient
to provide a default response and allow its code, message and data
to be altered.

@kellyredding - Ready for review. This is for https://github.com/redding/and-son/issues/30 and also to fix some usability suckiness with responses. Particularly the `status.message` thing. This is backwards compatible everything will work as-is and we can update at our leisure.
