### PR TITLE
Add `StringifyParams` module for normalizing request params

### DIFF
--- a/lib/sanford-protocol.rb
+++ b/lib/sanford-protocol.rb
@@ -49,5 +49,18 @@ module Sanford
       def decode(binary); ::BSON.deserialize(binary); end
     end
 
+    module StringifyParams
+      def self.new(object)
+        case(object)
+        when Hash
+          object.inject({}){ |h, (k, v)| h.merge(k.to_s => self.new(v)) }
+        when Array
+          object.map{ |item| self.new(item) }
+        else
+          object
+        end
+      end
+    end
+
   end
 end

--- a/lib/sanford-protocol/request.rb
+++ b/lib/sanford-protocol/request.rb
@@ -1,11 +1,7 @@
-# The Request class models a specific type of Sanford message body and provides
-# a defined structure for it. A request requires a message body to contain a
-# name and params.
+require 'sanford-protocol'
 
 module Sanford; end
 module Sanford::Protocol
-
-  BadRequestError = Class.new(RuntimeError)
 
   class Request
 
@@ -17,12 +13,13 @@ module Sanford::Protocol
 
     def initialize(name, params)
       self.validate!(name, params)
-      @name, @params = name.to_s, params
+      @name   = name.to_s
+      @params = params
     end
 
     def to_hash
       { 'name'   => name,
-        'params' => self.stringify(params)
+        'params' => Sanford::Protocol::StringifyParams.new(params)
       }
     end
 
@@ -49,21 +46,12 @@ module Sanford::Protocol
       problem = if !name
         "The request doesn't contain a name."
       elsif !params.kind_of?(::Hash)
-        "The request's params are not a valid BSON document."
+        "The request's params are not valid."
       end
-      raise(BadRequestError, problem) if problem
+      raise(InvalidError, problem) if problem
     end
 
-    def stringify(object)
-      case(object)
-      when Hash
-        object.inject({}){|h, (k, v)| h.merge({ k.to_s => self.stringify(v) }) }
-      when Array
-        object.map{|item| self.stringify(item) }
-      else
-        object
-      end
-    end
+    InvalidError = Class.new(ArgumentError)
 
   end
 

--- a/test/unit/sanford-protocol_tests.rb
+++ b/test/unit/sanford-protocol_tests.rb
@@ -20,27 +20,27 @@ module Sanford::Protocol
     should "encode the protocol version to a 1B binary string" do
       assert_equal 1, subject.msg_version.bytesize
 
-      expected = [ subject::VERSION ].pack('C')
-      assert_equal expected, subject.msg_version
+      exp = [subject::VERSION].pack('C')
+      assert_equal exp, subject.msg_version
     end
 
     should "encode/decode the size to/from a 4B binary string" do
       assert_equal 4, subject.msg_size.bytes
 
       size   = (2 ** 32) - 1 # the max number it supports
-      binary = [ size ].pack('N')
+      binary = [size].pack('N')
       assert_equal binary, subject.msg_size.encode(size)
       assert_equal size,   subject.msg_size.decode(binary)
     end
 
     should "encode the body to BSON" do
       data = {
-        'string'  => 'test',
-        'int'     => 1,
-        'float'   => 2.1,
-        'boolean' => true,
-        'array'   => [ 1, 2, 3 ],
-        'hash'    => { 'something' => 'else' }
+        'string'  => Factory.string,
+        'int'     => Factory.integer,
+        'float'   => Factory.float,
+        'boolean' => Factory.boolean,
+        'array'   => Factory.integer(3).times.map{ Factory.integer },
+        'hash'    => { Factory.string => Factory.string }
       }
       binary = ::BSON.serialize(data).to_s
 
@@ -49,4 +49,28 @@ module Sanford::Protocol
     end
 
   end
+
+  class StringifyParamsTests < UnitTests
+    desc "StringifyParams"
+    subject{ StringifyParams }
+
+    should have_imeths :new
+
+    should "convert all hash keys to strings" do
+      key, value = Factory.string.to_sym, Factory.string
+      result = subject.new({
+        key    => value,
+        :hash  => { key => [value] },
+        :array => [{ key => value }]
+      })
+      exp = {
+        key.to_s => value,
+        'hash'   => { key.to_s => [value] },
+        'array'  => [{ key.to_s => value }]
+      }
+      assert_equal exp, result
+    end
+
+  end
+
 end


### PR DESCRIPTION
This adds a `StringifyParams` module that is used to normalize
request params. This will be used by Sanford and AndSon to
serialize params in their test helpers. This is to help ensure
that params used in tests are valid and help make users tests
more robust.

The `StringifyParams` logic was pulled out of the `Request` class.
Building a request would stringify its params when converted to a
hash.

This makes one functionality change. The `Request` now raises an
`InvalidError` which is under the `Request` namespace. This
matches our latest conventions and what was done in Qs. The error
is still raised in the same scenarios though.

This also cleans up the tests for the `Sanford::Protocol` module
and the `Request` class. This changes any static data to use
randomized data from the factory. It also updates them to our
latest conventions. This involved essentially reworking the request
tests.

@kellyredding - Ready for review. Setup for serializing test params in Sanford and AndSon. Took the chance to do a little house cleaning.