### PR TITLE
response: rework status/handling

### DIFF
--- a/lib/sanford-protocol/connection.rb
+++ b/lib/sanford-protocol/connection.rb
@@ -21,7 +21,7 @@ module Sanford::Protocol
     # |   msg version   |  msg body size  |       msg body       |
     # |-----------------|-----------------|----------------------|
 
-    def read(timeout=nil)
+    def read(timeout = nil)
       wait_for_data(timeout) if timeout
       MsgVersion.new{ @socket.read msg_version.bytesize }.validate!
       size = MsgSize.new{ @socket.decode msg_size, msg_size.bytes }.validate!.value
@@ -35,7 +35,7 @@ module Sanford::Protocol
       @socket.write(msg_version, size, body)
     end
 
-    def peek(timeout=nil)
+    def peek(timeout = nil)
       wait_for_data(timeout) if timeout
       @socket.peek
     end

--- a/lib/sanford-protocol/fake_socket.rb
+++ b/lib/sanford-protocol/fake_socket.rb
@@ -15,13 +15,13 @@ module Sanford::Protocol
       self.with_msg_body(request.to_hash)
     end
 
-    def self.with_msg_body(body, size=nil, encoded_version=nil)
+    def self.with_msg_body(body, size = nil, encoded_version = nil)
       encoded_body = Sanford::Protocol.msg_body.encode(body)
       self.with_encoded_msg_body(encoded_body, size, encoded_version)
     end
 
-    def self.with_encoded_msg_body(encoded_body, size=nil, encoded_version=nil)
-      encoded_size    =   Sanford::Protocol.msg_size.encode(size || encoded_body.bytesize)
+    def self.with_encoded_msg_body(encoded_body, size = nil, encoded_version = nil)
+      encoded_size      = Sanford::Protocol.msg_size.encode(size || encoded_body.bytesize)
       encoded_version ||= Sanford::Protocol.msg_version
       self.new(encoded_version, encoded_size, encoded_body)
     end

--- a/lib/sanford-protocol/msg_data.rb
+++ b/lib/sanford-protocol/msg_data.rb
@@ -2,7 +2,7 @@ module Sanford; end
 module Sanford::Protocol
 
   class BadMessageError < RuntimeError
-    def initialize(message, bt=nil)
+    def initialize(message, bt = nil)
       super(message)
       set_backtrace(bt || caller)
     end
@@ -11,7 +11,7 @@ module Sanford::Protocol
   class MsgData
     attr_reader :value
 
-    def initialize(called_from=nil, &get_value)
+    def initialize(called_from = nil, &get_value)
 
       # By default, any exceptions from getting the value are "hidden" behind a
       # more general `BadMessageError`. In non-debug scenarios this is ideal and

--- a/lib/sanford-protocol/response.rb
+++ b/lib/sanford-protocol/response.rb
@@ -13,18 +13,18 @@ module Sanford::Protocol
       self.new(hash['status'], hash['data'])
     end
 
-    def initialize(status, data=nil)
+    def initialize(status, data = nil)
       super(build_status(status), data)
     end
 
-    def code;                  status.code;                  end
-    def code=(new_code);       status.code = new_code;       end
-    def message;               status.message;               end
-    def message=(new_message); status.message = new_message; end
-    def to_s;                  status.to_s;                  end
+    def code;            status.code;            end
+    def code=(value);    status.code = value;    end
+    def message;         status.message;         end
+    def message=(value); status.message = value; end
+    def to_s;            status.to_s;            end
 
     def to_hash
-      { 'status' => [ status.code, status.message ],
+      { 'status' => [status.code, status.message],
         'data'   => data
       }
     end

--- a/lib/sanford-protocol/response_status.rb
+++ b/lib/sanford-protocol/response_status.rb
@@ -26,25 +26,21 @@ module Sanford::Protocol
     end
 
     class Code < Struct.new(:number, :name)
-      NUMBERS = {
-        'ok'          => 200,
-        'bad_request' => 400,
-        'not_found'   => 404,
-        'timeout'     => 408,
-        'error'       => 500
+      NAMES = {
+        200 => 'OK',
+        400 => 'BAD REQUEST',
+        404 => 'NOT FOUND',
+        408 => 'TIMEOUT',
+        422 => 'INVALID',
+        500 => 'ERROR'
       }.freeze
 
-      def initialize(key)
-        num  = NUMBERS[key.to_s]  || key.to_i
-        name = NUMBERS.index(num) || NoName
-        super(num, name.upcase)
+      def initialize(number)
+        n = number.to_i
+        super(n, NAMES[n])
       end
 
       def to_s; "[#{[number, name].compact.join(', ')}]"; end
-
-      class NoName
-        def self.upcase; nil; end
-      end
     end
 
   end

--- a/test/unit/connection_tests.rb
+++ b/test/unit/connection_tests.rb
@@ -44,7 +44,7 @@ class Sanford::Protocol::Connection
     def start_server(options, &block)
       begin
         # this `fork` is a separate process, so it runs parallel to the code
-        # after it's block
+        # after its block
         pid = fork do
           tcp_server = TCPServer.open 'localhost', 12000
           trap("TERM"){ tcp_server.close }

--- a/test/unit/response_status_tests.rb
+++ b/test/unit/response_status_tests.rb
@@ -6,46 +6,55 @@ class Sanford::Protocol::ResponseStatus
   class UnitTests < Assert::Context
     desc "Sanford::Protocol::ResponseStatus"
     setup do
-      @status = Sanford::Protocol::ResponseStatus.new(200, "OK")
+      @status_class = Sanford::Protocol::ResponseStatus
+      @code = Factory.integer
+      @msg  = Factory.string
+      @status = @status_class.new(@code, @msg)
     end
     subject{ @status }
 
     should have_readers :code_obj, :message
     should have_imeths :code, :code=, :name, :to_i
 
-    should "know it's code name" do
-      named  = Sanford::Protocol::ResponseStatus.new(200)
-      unamed = Sanford::Protocol::ResponseStatus.new(999)
-
-      assert_equal "OK", named.name
-      assert_equal nil,  unamed.name
+    should "know its code obj and message" do
+      assert_kind_of Code, subject.code_obj
+      assert_equal @code,  subject.code_obj.number
+      assert_equal @msg,   subject.message
     end
 
-    should "know it's code number" do
-      Code::NUMBERS.each do |name, value|
-        status = Sanford::Protocol::ResponseStatus.new(name)
-        assert_equal value, status.code
-      end
+    should "know its code numbers" do
+      assert_equal subject.code_obj.number, subject.code
+      assert_equal subject.code,            subject.to_i
 
-      unamed = Sanford::Protocol::ResponseStatus.new('unamed')
-      assert_equal 0, unamed.code
+      assert_equal 0, @status_class.new(Factory.string).code
     end
 
-    should "return it's code number with #to_i" do
-      assert_equal subject.code, subject.to_i
+    should "know its code names" do
+      assert_equal subject.code_obj.name, subject.name
+
+      assert_equal 'OK',          @status_class.new(200).name
+      assert_equal 'BAD REQUEST', @status_class.new(400).name
+      assert_equal 'NOT FOUND',   @status_class.new(404).name
+      assert_equal 'TIMEOUT',     @status_class.new(408).name
+      assert_equal 'INVALID',     @status_class.new(422).name
+      assert_equal 'ERROR',       @status_class.new(500).name
+      assert_equal nil,           @status_class.new(Factory.integer+500).name
     end
 
     should "allow setting its code" do
-      number = Factory.integer
+      number = [200, 400, 404, 408, 422, 500].sample
       subject.code = number
-      assert_equal number, subject.code
+
+      exp_status = @status_class.new(number)
+      assert_equal exp_status.code, subject.code
+      assert_equal exp_status.name, subject.name
     end
 
-    should "return it's code number and code name with #to_s" do
-      named  = Sanford::Protocol::ResponseStatus.new(200)
-      unamed = Sanford::Protocol::ResponseStatus.new(999)
-
+    should "return its code number and code name with #to_s" do
+      named = @status_class.new([200, 400, 404, 408, 422, 500].sample)
       assert_equal "[#{named.code}, #{named.name}]", named.to_s
+
+      unamed = @status_class.new(Factory.integer+500)
       assert_equal "[#{unamed.code}]", unamed.to_s
     end
 

--- a/test/unit/response_tests.rb
+++ b/test/unit/response_tests.rb
@@ -6,95 +6,97 @@ class Sanford::Protocol::Response
   class UnitTests < Assert::Context
     desc "Sanford::Protocol::Response"
     setup do
-      @response = Sanford::Protocol::Response.new([ 672, 'YAR!' ], { 'something' => true })
+      @num  = Factory.integer+500
+      @msg  = Factory.string
+      @data = { Factory.string => Factory.string }
+
+      @response_class = Sanford::Protocol::Response
+      @response = @response_class.new([@num, @msg], @data)
     end
     subject{ @response }
 
-    should have_imeths :status, :data, :to_hash
-    should have_imeths :code, :code=, :message, :message=, :to_s
     should have_cmeths :parse
+    should have_imeths :status, :data
+    should have_imeths :code, :code=, :message, :message=
+    should have_imeths :to_s, :to_hash
+
+    should "know its status and data" do
+      assert_equal @num,  subject.status.code
+      assert_equal @msg,  subject.status.message
+      assert_equal @data, subject.data
+    end
 
     should "demeter its status" do
-      assert_equal subject.status.code, subject.code
+      assert_equal subject.status.code,    subject.code
       assert_equal subject.status.message, subject.message
-      assert_equal subject.status.to_s, subject.to_s
+      assert_equal subject.status.to_s,    subject.to_s
 
-      new_code = Factory.integer
-      new_message = Factory.string
-      subject.code = new_code
-      subject.message = new_message
+      subject.code    = new_code = Factory.integer
+      subject.message = new_msg  = Factory.string
       assert_equal new_code, subject.code
-      assert_equal new_message, subject.message
+      assert_equal new_msg,  subject.message
     end
 
-    should "return an instance of a Sanford::Protocol::Response given a hash using #parse" do
-      # using BSON messages are hashes
+    should "know its hash representation" do
+      # BSON messages are hashes
+      exp = {
+        'status' => [@num, @msg],
+        'data'   => @data
+      }
+      assert_equal exp, subject.to_hash
+    end
+
+    should "should parse hash representations into objects" do
+      # BSON messages are hashes
       hash = {
-        'status' => [ 200, 'OK' ],
-        'data'   => 'yes'
+        'status' => [Factory.integer, Factory.string],
+        'data'   => Factory.string
       }
-      request = Sanford::Protocol::Response.parse(hash)
+      response = @response_class.parse(hash)
 
-      assert_instance_of Sanford::Protocol::Response, request
-      assert_equal hash['status'].first, request.status.code
-      assert_equal hash['status'].last,  request.status.message
-      assert_equal hash['data'],         request.data
+      assert_instance_of @response_class, response
+      assert_equal hash['status'].first, response.status.code
+      assert_equal hash['status'].last,  response.status.message
+      assert_equal hash['data'],         response.data
     end
 
-    should "return the request as a hash with #to_hash" do
-      # using BSON messages are hashes
-      expected = {
-        'status' => [ 672, 'YAR!' ],
-        'data'   => { 'something' => true }
-      }
+    should "know if it is equal to another response" do
+      equal = @response_class.new(subject.status.dup, subject.data.dup)
+      assert_equal equal, subject
 
-      assert_equal expected, subject.to_hash
-    end
+      not_equal = @response_class.new(Factory.integer, subject.data.dup)
+      assert_not_equal not_equal, subject
 
-    should "be comparable" do
-      match_response = Sanford::Protocol::Response.new(
-        subject.status.dup,
-        subject.data.dup
-      )
-      assert_equal match_response, subject
-
-      not_match_response = Sanford::Protocol::Response.new(123, {})
-      assert_not_equal not_match_response, subject
+      not_equal = @response_class.new(subject.status.dup, {})
+      assert_not_equal not_equal, subject
     end
 
   end
 
   # Somewhat of a system test, want to make sure if Response is passed some
-  # "fuzzy" args that it will build it's status object as expected
+  # "fuzzy" args that it will build its status object as expected
   class StatusBuildingTests < UnitTests
 
-    should "build a status with it's code set, given an integer" do
-      response = Sanford::Protocol::Response.new(574)
+    should "build a status with its code set if given an integer" do
+      response = Sanford::Protocol::Response.new(@num)
 
-      assert_equal 574, response.status.code
-      assert_equal nil, response.status.message
-    end
-
-    should "build a status with it's code set, given a name" do
-      response = Sanford::Protocol::Response.new('ok')
-
-      assert_equal 200, response.status.code
-      assert_equal nil, response.status.message
+      assert_equal @num, response.status.code
+      assert_equal nil,  response.status.message
     end
 
     should "use a status object, if given one" do
-      status = Sanford::Protocol::ResponseStatus.new(200, "OK")
+      status   = Sanford::Protocol::ResponseStatus.new(@num, @msg)
       response = Sanford::Protocol::Response.new(status)
-
       assert_same status, response.status
     end
 
     should "build a status with a code and message set, when given both" do
-      response = Sanford::Protocol::Response.new([ 348, "my message" ])
+      response = Sanford::Protocol::Response.new([@num, @msg])
 
-      assert_equal 348, response.status.code
-      assert_equal "my message", response.status.message
+      assert_equal @num, response.status.code
+      assert_equal @msg, response.status.message
     end
+
   end
 
 end


### PR DESCRIPTION
This is a number of small reworks to the response status, how it is
specified and how it is handled.  The goal here is to simplify the
logic a bit based on known usage patterns.  However, there are some
backwards incompatible changes here.

The need for simplifications was originally brought to attention
when testing this gem in modern ruby versions.  In 1.8.7, you lookup
a Hash value's key with the `index` method.  In modern ruby, you
look it up using the `key` method (ugh).  The previous status code
and name lookup logic used `index` to lookup a key if a value was
given.  To support this old logic in modern ruby, I'd have to add
a 1.8.7 conditional check (double-ugh).  I really don't like having
to have version checks in the code (although ruby is kinda forcing
it on this issue b/c they won't alias 1.8.7 methods) so Collin and
I decided to just simplify the feature.

This changes so that you can only specify response statuses using
a code integer (where previously you could use either the code
integer or a designated name string).  Dropping lookup by name
string allowed reworking the names lookup to be by code integer and
removed the need for the index/key method.  This is also simpler
overall (we found we never used the dumb name strings in practice
anyway) and also allows cleaning up the names to not use underscores
(which is just a minor aesthetic improvement).

In addition, there are a few other minor tweaks happening:
- added a formal named status for 422 ("INVALID")
- updates the response-related tests to get them up to our latest
  conventions
- switched to using randomized factory data where possible
- more thoroughly tested the response status
- tested each code/name mapping explicitly
- a bunch of minor style cleanups 

@jcredding ready for review.  Does this jive with what we discussed?  Are you cool with me adding that named status?
